### PR TITLE
Add DeepSeek API key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A simple desktop application for transcribing audio from video files using Faste
 *   **Basic Subtitle Editor**: Edit the text and timestamps of generated subtitles directly within the application.
 *   **Preview Video with Subtitles**: Attempt to open the selected video with its generated subtitles in your default media player.
 *   **Multiple Translation API Support**: Choose between Google Gemini, OpenAI, Anthropic Claude, and DeepSeek for translations.
+*   **API Key Validation**: Built-in checks verify Gemini, OpenAI, Anthropic, and DeepSeek keys before use.
 *   **Model Selection for Providers**: 
     *   Select specific models for Gemini (`gemini-2.5-flash-preview-04-17` or `gemini-2.5-pro-exp-03-25`)
     *   Choose from OpenAI models (GPT-4.1, GPT-4o, etc.) 

--- a/dialogs/advanced_settings.py
+++ b/dialogs/advanced_settings.py
@@ -571,8 +571,8 @@ class AdvancedSettingsDialog(QDialog):
         self.deepseek_validate_button.setText("Validating...")
         
         def validation_thread_task():
-            valid = True  # Placeholder, no validation for DeepSeek yet
-            message = "DeepSeek key validation not implemented yet."
+            from backend.translate import validate_deepseek_key
+            valid, message = validate_deepseek_key(api_key, self.app.log_status)
             
             # Update UI in main thread
             from PySide6.QtCore import QMetaObject, Qt, Q_ARG

--- a/docs/api.html
+++ b/docs/api.html
@@ -32,6 +32,7 @@
                 <div class="note">
                     <p><strong>Catatan Keamanan:</strong> API key disimpan dengan enkripsi pada aplikasi ini, tetapi tetap penting untuk menjaga keamanan dan kerahasiaan API key Anda. Jangan bagikan API key dengan orang lain.</p>
                 </div>
+                <p class="note">Aplikasi menyediakan fitur validasi API key untuk Gemini, OpenAI, Anthropic, dan DeepSeek.</p>
             </section>
             
             <section id="gemini-api">

--- a/docs/index.html
+++ b/docs/index.html
@@ -175,6 +175,7 @@
                 </ul>
                 
                 <p class="note">Catatan: Setiap provider membutuhkan API key masing-masing. Lihat <a href="api.html">Konfigurasi API</a> untuk petunjuk lebih lanjut.</p>
+                <p class="note">Semua penyedia mendukung validasi API key langsung dari jendela Advanced Settings.</p>
             </section>
             
             <section id="subtitle-styling">


### PR DESCRIPTION
## Summary
- validate DeepSeek API keys in backend
- hook up DeepSeek validation in Advanced Settings dialog
- check key validity before running DeepSeek translations
- document provider validation support

## Testing
- `python -m py_compile backend/translate.py dialogs/advanced_settings.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_684567738e90832bb997f6def6a5ecc4